### PR TITLE
creates a cli for listing discovered plugins

### DIFF
--- a/esm_plugin_manager/cli.py
+++ b/esm_plugin_manager/cli.py
@@ -1,0 +1,17 @@
+def main():
+    import pkg_resources
+
+    discovered_plugins = {
+        entry_point.name: entry_point.load()
+        for entry_point
+        in pkg_resources.iter_entry_points('esm_tools.plugins')
+    }
+
+    for plugin_name, plugin_code in discovered_plugins.items():
+        print(plugin_name)
+        doc = getattr(plugin_code, "__doc__")
+        if doc:
+            print("-"*len(plugin_name))
+            print(doc)
+        print("\n")
+

--- a/setup.py
+++ b/setup.py
@@ -45,4 +45,5 @@ setup(
     url='https://github.com/dbarbi/esm_plugin_manager',
     version='4.0.0',
     zip_safe=False,
+    entry_points = {"console_scripts": ["esm_plugins=esm_plugin_manager.cli:main"]}
 )


### PR DESCRIPTION
Any package that lists an entry point of the form:
```python
setup(
... other stuff ...
entry_points = {"esm_tools.plugins": ["some_module.some_function"]
)
```

Can now be listed like this:
```
$ esm_plugins

esm_mesh_part_prep
------------------

    Runs a pre-process script for the mesh partioner to generate 3D information
```