### PR TITLE
Plugin entrypoint

### DIFF
--- a/esm_plugin_manager/cli.py
+++ b/esm_plugin_manager/cli.py
@@ -1,0 +1,13 @@
+from .esm_plugin_manager import find_installed_plugins
+
+def main():
+    discovered_plugins = find_installed_plugins()
+    for plugin_name in discovered_plugins:
+        plugin_code = discovered_plugins[plugin_name]["callable"]
+        print(plugin_name)
+        doc = getattr(plugin_code, "__doc__")
+        if doc:
+            print("-"*len(plugin_name))
+            print(doc)
+        print("\n")
+

--- a/esm_plugin_manager/esm_plugin_manager.py
+++ b/esm_plugin_manager/esm_plugin_manager.py
@@ -68,7 +68,7 @@ def check_plugin_availability(plugins):
     for workitem in list(plugins.keys()):
         if plugins[workitem]["type"] == "core":
             pass
-        elif plugin[workitem]["type"] == "installed":
+        elif plugins[workitem]["type"] == "installed":
             pass
         else:
             print ("Checking if function " + plugins[workitem]["module"] + "." +
@@ -93,10 +93,8 @@ def work_through_recipe(recipe, plugins, config):
             submodule = getattr(thismodule, plugins[workitem]["submodule"])
             config = getattr(submodule, workitem)(config)
         elif plugins[workitem]["type"] == "installed":
-            print("Installed plugin will be run!")
-            import pdb; pdb.set_trace()
+            # print("Installed plugin will be run: ", workitem)
             config = plugins[workitem]["callable"](config)
-            sys.exit(-1)
         else:
             if sys.version_info >= (3, 5):
                 import importlib.util

--- a/setup.py
+++ b/setup.py
@@ -45,4 +45,5 @@ setup(
     url='https://github.com/dbarbi/esm_plugin_manager',
     version='4.0.0',
     zip_safe=False,
+    entry_points = {"console_scripts": ["esm_plugins=esm_plugin_manager.cli:main"]},
 )


### PR DESCRIPTION
# Allows the user to "install" plugins via pip.

It might nice to allow users to actually distribute plugins much like we distribute Python code: e.g. no one needs to email around "use this scripts as a plugin", and they can instead just do "pip install ..."

For this to work, we register an "entry point", in the setup.py file, like this:

```
setup(
    ...
    entry_points={'esm_tools.plugin': 'plugin_name = module.submodule:function'},
    ...
)
```

This works similarly to how the `console_scripts` entry point is written down for a command line interface. More info in the last section here: https://packaging.python.org/guides/creating-and-discovering-plugins/

In the recipe, you can now mention `plugin_name`, and it will be imported and called at the appropriate time.

Here is an example for a plugin to deal with the FESOM mesh partioner, which needs some pre-processing:

https://github.com/pgierz/mesh_part_prep

Entry points:
```python
setup(
....
entry_points = {
"console_scripts" : ["mesh_part_prep=mesh_part_prep.cli:main"],
"esm_tools.plugins": ["mesh_part_prep=mesh_part_prep.plugin:esm_mesh_part_prep"]
}
...
```